### PR TITLE
bin2s: don't forget the trailing newline of the assembly output

### DIFF
--- a/bin2s.c
+++ b/bin2s.c
@@ -285,7 +285,7 @@ int main(int argc, char **argv) {
 			fprintf( stdout, "_size: .int %lu\n", (unsigned long)filelen);
 		}
 
-		fputs("\n\n#if defined(__linux__) && defined(__ELF__)\n.section .note.GNU-stack,\"\",%progbits\n#endif", stdout);
+		fputs("\n\n#if defined(__linux__) && defined(__ELF__)\n.section .note.GNU-stack,\"\",%progbits\n#endif\n", stdout);
 		fclose(fin);
 	}
 


### PR DESCRIPTION
the gcc command in bin2o doesn't seem to care, but technically assembly files should end with a newline (AS throws warnings if it isn't for example).

when the section was added to support the upcoming ld change, the trailing newline was overwritten :)