### PR TITLE
bin2s: add missing newline at the end of the output

### DIFF
--- a/bin2s.c
+++ b/bin2s.c
@@ -285,7 +285,7 @@ int main(int argc, char **argv) {
 			fprintf( stdout, "_size: .int %lu\n", (unsigned long)filelen);
 		}
 
-		fputs("\n\n#if defined(__linux__) && defined(__ELF__)\n.section .note.GNU-stack,\"\",%progbits\n#endif", stdout);
+		fputs("\n\n#if defined(__linux__) && defined(__ELF__)\n.section .note.GNU-stack,\"\",%progbits\n#endif\n", stdout);
 		fclose(fin);
 	}
 


### PR DESCRIPTION
In a recent change there was new text appended at the end of the output, but a newline was forgotten, raising the warning ``end of file in comment, new line inserted " when building the outputted source.