### PR TITLE
Added a newline at the end of the output

### DIFF
--- a/bin2s.c
+++ b/bin2s.c
@@ -285,7 +285,7 @@ int main(int argc, char **argv) {
 			fprintf( stdout, "_size: .int %lu\n", (unsigned long)filelen);
 		}
 
-		fputs("\n\n#if defined(__linux__) && defined(__ELF__)\n.section .note.GNU-stack,\"\",%progbits\n#endif", stdout);
+		fputs("\n\n#if defined(__linux__) && defined(__ELF__)\n.section .note.GNU-stack,\"\",%progbits\n#endif\n", stdout);
 		fclose(fin);
 	}
 


### PR DESCRIPTION
This prevents the potentional warning complaining missing of newline when the output is directly piped to the assembler, e.g. " Warning: end of file in comment; newline inserted" from GNU as.